### PR TITLE
feat(next): explicit es and cjs compatibility

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/fostyfost/redux-eggs",
   "main": "dist/index.server.js",
-  "module": "dist/index.server.js",
+  "module": "dist/index.server.es.js",
   "browser": "dist/index.client.js",
   "types": "dist/index.server.d.ts",
   "files": [

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -11,9 +11,9 @@
     "url": "https://github.com/fostyfost/redux-eggs/issues"
   },
   "homepage": "https://github.com/fostyfost/redux-eggs",
-  "main": "dist/index.server.js",
+  "main": "dist/index.server.es.js",
   "module": "dist/index.server.es.js",
-  "browser": "dist/index.client.js",
+  "browser": "dist/index.client.es.js",
   "types": "dist/index.server.d.ts",
   "files": [
     "dist"

--- a/packages/next/rollup.config.js
+++ b/packages/next/rollup.config.js
@@ -43,6 +43,14 @@ const getDefaultConfig = (tsOptions = {}, addTerser = false) => {
 
 const config = [
   {
+    ...getDefaultConfig(),
+    input: './src/server/index.tsx',
+    output: {
+      file: './dist/index.server.es.js',
+      format: 'es',
+    },
+  },
+  {
     ...getDefaultConfig({
       tsconfig: resolvedConfig => ({
         ...resolvedConfig,
@@ -52,15 +60,28 @@ const config = [
     input: './src/server/index.tsx',
     output: {
       file: './dist/index.server.js',
-      format: 'es',
+      format: 'cjs',
     },
   },
   {
     ...getDefaultConfig({ browserslist: ['defaults'] }, true),
     input: './src/client/index.tsx',
     output: {
-      file: './dist/index.client.js',
+      file: './dist/index.client.es.js',
       format: 'es',
+    },
+  },
+  {
+    ...getDefaultConfig({
+      tsconfig: resolvedConfig => ({
+        ...resolvedConfig,
+        declaration: true,
+      }),
+    }),
+    input: './src/client/index.tsx',
+    output: {
+      file: './dist/index.client.js',
+      format: 'cjs',
     },
   },
 ]


### PR DESCRIPTION
In our typescript codebase the ES module based dist files weren't recognised as such. Furthermore, there was no CJS support. I've aligned the next package with the other packages, like React, Core etc.

Please refer to: https://github.com/fostyfost/redux-eggs/issues/752